### PR TITLE
Updated department names

### DIFF
--- a/departments.json
+++ b/departments.json
@@ -32,7 +32,7 @@
       "name": "Bundesministerium der Verteidigung"
     },
     {
-      "name": "Bundesministerium des Innern",
+      "name": "Bundesministerium des Innern und Heimat",
       "subordinates": [
         {
           "name": "Bundesinstitut für Bau-, Stadt- und Raumforschung (BBSR) im Bundesamt für Bauwesen und Raumordnung (BBR)"
@@ -66,13 +66,13 @@
       "name": "Bundesministerium für wirtschaftliche Zusammenarbeit und Entwicklung"
     },
     {
-      "name": "Bundesministerium für Wirtschaft und Energie",
+      "name": "Bundesministerium für Wirtschaft und Klimaschutz",
       "subordinates": [
         {
           "name": "Bundesamt für Wirtschaft und Ausfuhrkontrolle"
         },
         {
-          "name": "Bundesanstalt für Materialforschung und -prüfung "
+          "name": "Bundesanstalt für Materialforschung und -prüfung (BAM)"
         }
       ]
     },
@@ -99,7 +99,7 @@
       ]
     },
     {
-      "name": "Bundesministerium für Verkehr und digitale Infrastruktur",
+      "name": "Bundesministerium für Digitales und Verkehr",
       "subordinates": [
         {
           "name": "mCLOUD"


### PR DESCRIPTION
Hi,

as briefly discussed yesterday here an updated version of the departments.json

## Additional background:

When I compared the response of the govdata ckan api with the departments.json - I realized that some (display) names has changed - this PR includes my findings.

What do you thing about extending the departments.json?
My suggestion would be
(a) rename "name" to "display-name" and
(b) introducing the field "name" with the same values as we see in the gov data response, like "auswaertiges-amt"

I am not 100% sure but I think that the name is less likely to change (at least compared to the display name).
String comparison could become less error prone as the name is more machine friendly ;)

Let me know if you are interessted in another PR including the changes mentioned in the suggestion.

BR,
Alex
